### PR TITLE
get working with gatsby v1

### DIFF
--- a/src/markdownPages/resume.md
+++ b/src/markdownPages/resume.md
@@ -1,6 +1,6 @@
 ---
 title: Kyle Welch - Resume
-path: "resume"
+path: /resume
 ---
 
 ## Contact Details {.contact-details}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,6 +9,6 @@ export default () => (
       paddingTop: 0,
     }}
   >
-    Hello world!
+    <Link to="/resume">Go to resume</Link>
   </div>
 );


### PR DESCRIPTION
Fix was way easier than you thought probably :)

What I've also done in the past is left the Markdown as is, but then changed the `createPages` API call to prepend the forward slash. I've also seen people slugify the title, which works out pretty well too. That'd look something like this in `gatsby-node.js`

```js
const slugify = require('limax');

// then later

createPage({
  path: `/${slugify(node.frontmatter.title)}`,
  component: resumeTemplate,
  context: {}, // additional data can be passed via context
});
```

The above would require naming resume "Resume" but that's a fairly trivial change, as well!